### PR TITLE
PHP 8 support and enforcement of PHP 7.4 as min requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,9 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "ext-curl": "^7.2"
+        "php": "^7.4 || ~8.0",
+        "ext-curl": "^7.4 || ~8.0",
+        "ext-json": "^7.4 || ~8.0"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/src/Channel.php
+++ b/src/Channel.php
@@ -53,14 +53,14 @@ class Channel
      *
      * @var string
      */
-    protected $url = '';
+    protected string $url = '';
 
     /**
      * Curl options
      *
      * @var array
      */
-    protected $curlOptions = [];
+    protected array $curlOptions = [];
 
     /**
      * onReady callback
@@ -88,7 +88,7 @@ class Channel
      *
      * @var int
      */
-    protected $connectionTimeout;
+    protected int $connectionTimeout;
 
     /**
      * Sets URL
@@ -115,7 +115,7 @@ class Channel
     /**
      * Sets total timeout in milliseconds
      *
-     * @param int $timeout Total timeout in milliseconds (1000ms == 1s) or null if no timeout is required (default)
+     * @param int|null $timeout Total timeout in milliseconds (1000ms == 1s) or null if no timeout is required (default)
      * @return void
      */
     public function setTimeout(int $timeout = null): void
@@ -128,7 +128,7 @@ class Channel
      *
      * INFO: This timeout includes the socket connection as well as the SSL handshake
      *
-     * @param int $timeout Connection timeout in milliseconds (1000ms == 1s)
+     * @param int|null $timeout Connection timeout in milliseconds (1000ms == 1s)
      * @return void
      */
     public function setConnectionTimeout(int $timeout = null): void
@@ -143,7 +143,7 @@ class Channel
      * The default cURL timeout is 300,000 milliseconds
      * @see https://curl.haxx.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html
      *
-     * @return integer
+     * @return int
      */
     public function getConnectionTimeout() : int
     {
@@ -197,8 +197,8 @@ class Channel
      * @param int $type Type of proxy (see self::PROXY_* consts)
      * @param string $host Proxy hostname
      * @param int $port Proxy port
-     * @param string $username Username (or null if not applicable)
-     * @param string $password Password (or null if not applicable)
+     * @param string|null $username Username (or null if not applicable)
+     * @param string|null $password Password (or null if not applicable)
      */
     public function setProxy(int $type, string $host, int $port, string $username = null, string $password = null): void
     {
@@ -225,7 +225,7 @@ class Channel
      * @param mixed $value
      * @return void
      */
-    public function setCurlOption($option, $value): void
+    public function setCurlOption(int $option, $value): void
     {
         $this->curlOptions[$option] = $value;
     }
@@ -289,8 +289,8 @@ class Channel
     /**
      * Called from Manager when curl channel is timed out
      *
-     * @param integer $timeoutType Type of timeout, either TIMEOUT_CONNECTION or TIMEOUT_TOTAL
-     * @param integer $elapsedMS Elapsed milliseconds (1000ms = 1s)
+     * @param int $timeoutType Type of timeout, either TIMEOUT_CONNECTION or TIMEOUT_TOTAL
+     * @param int $elapsedMS Elapsed milliseconds (1000ms = 1s)
      * @param Manager $manager Manager instance
      * @return void
      */
@@ -303,7 +303,7 @@ class Channel
      * Called from Manager when curl encountered an error other than timeout
      *
      * @param string $message Curl error message
-     * @param integer $errno Curl error code (@see https://curl.haxx.se/libcurl/c/libcurl-errors.html)
+     * @param int $errno Curl error code (@see https://curl.haxx.se/libcurl/c/libcurl-errors.html)
      * @param array $info Output of curl_getinfo (@see https://php.net/curl_getinfo)
      * @param Manager $manager Manager instance
      * @return void

--- a/src/HttpChannel.php
+++ b/src/HttpChannel.php
@@ -51,42 +51,42 @@ class HttpChannel extends Channel
      *
      * @var array
      */
-    protected $validMethods = [self::METHOD_GET, self::METHOD_POST];
+    protected array $validMethods = [self::METHOD_GET, self::METHOD_POST];
 
     /**
      * HTTP method
      *
      * @var string
      */
-    protected $method;
+    protected string $method;
 
     /**
      * GET/POST body data
      *
-     * @var string
+     * @var string|null
      */
-    protected $body;
+    protected ?string $body = null;
 
     /**
      * Content-Type for body data
      *
-     * @var string
+     * @var string|null
      */
-    protected $contentType;
+    protected ?string $contentType = null;
 
     /**
      * Headers
      *
      * @var array
      */
-    protected $headers = [];
+    protected array $headers = [];
 
     /**
      * Prototype object for ::create factory
      *
-     * @var self
+     * @var HttpChannel
      */
-    protected static $prototype;
+    protected static HttpChannel $prototype;
 
     /**
      * Constructor
@@ -94,7 +94,7 @@ class HttpChannel extends Channel
      * @param string $url URL
      * @param string $method HTTP Method (see self::METHOD_* consts)
      * @param string|array|null $body Body (string or array)
-     * @param string $contentType Content-Type
+     * @param string|null $contentType Content-Type
      */
     public function __construct(string $url, string $method = self::METHOD_GET, $body = null, string $contentType = null)
     {
@@ -139,7 +139,7 @@ class HttpChannel extends Channel
      * Sets body content and type
      *
      * @param mixed $body
-     * @param string $contentType
+     * @param string|null $contentType
      * @return void
      */
     public function setBody($body, string $contentType = null): void
@@ -158,7 +158,7 @@ class HttpChannel extends Channel
     /**
      * Sets HTTP version
      *
-     * @param integer $version
+     * @param int|null $version
      * @return void
      */
     public function setHttpVersion(int $version = null): void
@@ -170,7 +170,7 @@ class HttpChannel extends Channel
      * Sets or removes a header
      *
      * @param string $name Name
-     * @param string $value Value (if null, header is removed)
+     * @param string|null $value Value (if null, header is removed)
      * @return void
      */
     public function setHeader(string $name, string $value = null): void
@@ -215,7 +215,7 @@ class HttpChannel extends Channel
      * @param string $cookieJar Cookie jar file path
      * @return void
      */
-    public function setCookieJarFile($cookieJar): void
+    public function setCookieJarFile(string $cookieJar): void
     {
         $this->setCurlOption(CURLOPT_COOKIEJAR, $cookieJar);
         $this->setCurlOption(CURLOPT_COOKIEFILE, $cookieJar);
@@ -259,8 +259,8 @@ class HttpChannel extends Channel
      *
      * @param string $url URL
      * @param string $method HTTP Method (see self::METHOD_* consts)
-     * @param string $body Body (string or array)
-     * @param string $contentType Content-Type
+     * @param string|null $body Body (string or array)
+     * @param string|null $contentType Content-Type
      */
     public static function create(string $url, string $method = self::METHOD_GET, string $body = null, string $contentType = null): self
     {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -84,7 +84,7 @@ class Manager
     /**
      * Multi-Curl handle
      *
-     * @var null|false|resource
+     * @var null|false|resource|\CurlHandle
      */
     protected $mh;
 
@@ -331,7 +331,7 @@ class Manager
      * Creates curl channel resource from Channel instance
      *
      * @param Channel $channel
-     * @return false|resource
+     * @return false|resource|\CurlHandle Depending on PHP version returns a resource or a CurlHandle
      * @noinspection PhpMissingReturnTypeInspection
      */
     protected function createCurlHandleFromChannel(Channel $channel)

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -41,21 +41,21 @@ class Manager
      *
      * @var int
      */
-    protected $maxConcurrency = 10;
+    protected int $maxConcurrency = 10;
 
     /**
      * Channel queue
      *
      * @var array
      */
-    protected $channelQueue = [];
+    protected array $channelQueue = [];
 
     /**
      * Lookup table for cURL resources to Channel instances
      *
      * @var array
      */
-    protected $resourceChannelLookup = [];
+    protected array $resourceChannelLookup = [];
 
     /**
      * Low watermark factor
@@ -63,9 +63,9 @@ class Manager
      * The low watermark for the channel queue is reached when there are less
      * than $maxConcurrency * $lowWatermarkFactor items left in the queue.
      *
-     * @var integer
+     * @var int
      */
-    protected $lowWatermarkFactor = 2;
+    protected int $lowWatermarkFactor = 2;
 
     /**
      * Queue refill callback
@@ -84,7 +84,7 @@ class Manager
     /**
      * Multi-Curl handle
      *
-     * @var \CurlMultiHandle
+     * @var null|false|resource
      */
     protected $mh;
 
@@ -93,20 +93,20 @@ class Manager
      *
      * @var array
      */
-    protected $delayQueue = [];
+    protected array $delayQueue = [];
 
     /**
      * Is delay queue sorted?
      *
      * @var bool
      */
-    protected $delayQueueSorted = false;
+    protected bool $delayQueueSorted = false;
 
 
     /**
      * Constructor
      *
-     * @param integer $maxConcurrency Max. concurrency (default 10)
+     * @param int $maxConcurrency Max. concurrency (default 10)
      */
     public function __construct(int $maxConcurrency = 10)
     {
@@ -121,9 +121,9 @@ class Manager
      * @param float $minDelay Minimum delay (in seconds) before channel is getting active
      * @return void
      */
-    public function addChannel(Channel $channel, bool $unshift = false, $minDelay = 0.0): void
+    public function addChannel(Channel $channel, bool $unshift = false, float $minDelay = 0.0): void
     {
-        if ($minDelay > 0) {
+        if ($minDelay > 0.0) {
             $this->delayQueue[] = [$channel, $unshift, microtime(true) + $minDelay];
             $this->delayQueueSorted = false;
             return;
@@ -311,7 +311,7 @@ class Manager
     /**
      * Adds channels from the queue to multi-curl
      *
-     * @param integer $number Maximum number of channels to add
+     * @param int $number Maximum number of channels to add
      * @return int The number of effectively added channels
      */
     protected function addNCurlResourcesToMultiCurl(int $number): int
@@ -331,7 +331,8 @@ class Manager
      * Creates curl channel resource from Channel instance
      *
      * @param Channel $channel
-     * @return \CurlHandle|resource
+     * @return false|resource
+     * @noinspection PhpMissingReturnTypeInspection
      */
     protected function createCurlHandleFromChannel(Channel $channel)
     {


### PR DESCRIPTION
- Added support for PHP 8 via composer.json
- Increased minimum required PHP version to 7.4 and added type hints to member variables as supported in 7.4.
- Added missing ext-json requirement to composer.json