### PR TITLE
improve RpcMessage::fromArray|toArray methods to keep `_meta` inside …

### DIFF
--- a/src/Mcp/RpcMessage.php
+++ b/src/Mcp/RpcMessage.php
@@ -378,9 +378,10 @@ class RpcMessage
             $message->method = $data['method'];
             $message->params = $data['params'] ?? null;
 
-            // Extract _meta from inside params (per MCP spec)
+            // Extract _meta from inside params (per MCP spec) — unset so _meta property is the single source of truth
             if (is_array($message->params) && isset($message->params['_meta']) && is_array($message->params['_meta'])) {
                 $message->_meta = $message->params['_meta'];
+                unset($message->params['_meta']);
             }
         } else {
             if (isset($data['error'])) {
@@ -390,9 +391,10 @@ class RpcMessage
                 $message->type = self::TYPE_RESPONSE;
                 $message->result = $data['result'] ?? null;
 
-                // Extract _meta from inside result (per MCP spec)
+                // Extract _meta from inside result (per MCP spec) — unset so _meta property is the single source of truth
                 if (is_array($message->result) && isset($message->result['_meta']) && is_array($message->result['_meta'])) {
                     $message->_meta = $message->result['_meta'];
+                    unset($message->result['_meta']);
                 }
             }
             $message->id = $data['id'] ?? null;

--- a/src/Mcp/RpcMessage.php
+++ b/src/Mcp/RpcMessage.php
@@ -398,7 +398,35 @@ class RpcMessage
             $message->id = $data['id'] ?? null;
         }
 
+        // Backward compat: also accept root-level _meta (old wire format)
+        if ($message->_meta === null && isset($data['_meta']) && is_array($data['_meta'])) {
+            $message->_meta = $data['_meta'];
+        }
+
         return $message;
+    }
+
+    /**
+     * Merge _meta into a payload (params or result), converting stdClass/null to array as needed.
+     */
+    private function mergeMetaIntoPayload(mixed $payload): mixed
+    {
+        if ($this->_meta === null) {
+            return $payload;
+        }
+
+        if ($payload instanceof \stdClass) {
+            $payload = (array)$payload;
+        } elseif ($payload === null) {
+            $payload = [];
+        }
+
+        if (is_array($payload)) {
+            $existing = is_array($payload['_meta'] ?? null) ? $payload['_meta'] : [];
+            $payload['_meta'] = array_merge($existing, $this->_meta);
+        }
+
+        return $payload;
     }
 
     /**
@@ -415,17 +443,7 @@ class RpcMessage
         if ($this->type === self::TYPE_REQUEST || $this->type === self::TYPE_NOTIFICATION) {
             $result['method'] = $this->method;
 
-            $params = $this->params;
-
-            if ($this->_meta !== null) {
-                if ($params === null || $params instanceof \stdClass) {
-                    $params = [];
-                }
-                if (is_array($params)) {
-                    $existing = is_array($params['_meta'] ?? null) ? $params['_meta'] : [];
-                    $params['_meta'] = array_merge($existing, $this->_meta);
-                }
-            }
+            $params = $this->mergeMetaIntoPayload($this->params);
 
             if ($params !== null) {
                 $result['params'] = $params;
@@ -438,19 +456,7 @@ class RpcMessage
             if ($this->type === self::TYPE_ERROR) {
                 $result['error'] = $this->error;
             } else {
-                $responseResult = $this->result;
-
-                if ($this->_meta !== null) {
-                    if ($responseResult === null || $responseResult instanceof \stdClass) {
-                        $responseResult = [];
-                    }
-                    if (is_array($responseResult)) {
-                        $existing = is_array($responseResult['_meta'] ?? null) ? $responseResult['_meta'] : [];
-                        $responseResult['_meta'] = array_merge($existing, $this->_meta);
-                    }
-                }
-
-                $result['result'] = $responseResult;
+                $result['result'] = $this->mergeMetaIntoPayload($this->result);
             }
 
             if ($this->id !== null) {

--- a/src/Mcp/RpcMessage.php
+++ b/src/Mcp/RpcMessage.php
@@ -377,6 +377,11 @@ class RpcMessage
             }
             $message->method = $data['method'];
             $message->params = $data['params'] ?? null;
+
+            // Extract _meta from inside params (per MCP spec)
+            if (is_array($message->params) && isset($message->params['_meta']) && is_array($message->params['_meta'])) {
+                $message->_meta = $message->params['_meta'];
+            }
         } else {
             if (isset($data['error'])) {
                 $message->type = self::TYPE_ERROR;
@@ -384,13 +389,13 @@ class RpcMessage
             } else {
                 $message->type = self::TYPE_RESPONSE;
                 $message->result = $data['result'] ?? null;
+
+                // Extract _meta from inside result (per MCP spec)
+                if (is_array($message->result) && isset($message->result['_meta']) && is_array($message->result['_meta'])) {
+                    $message->_meta = $message->result['_meta'];
+                }
             }
             $message->id = $data['id'] ?? null;
-        }
-
-        // Handle metadata if present
-        if (isset($data['_meta']) && is_array($data['_meta'])) {
-            $message->_meta = $data['_meta'];
         }
 
         return $message;
@@ -410,8 +415,20 @@ class RpcMessage
         if ($this->type === self::TYPE_REQUEST || $this->type === self::TYPE_NOTIFICATION) {
             $result['method'] = $this->method;
 
-            if ($this->params !== null) {
-                $result['params'] = $this->params;
+            $params = $this->params;
+
+            if ($this->_meta !== null) {
+                if ($params === null || $params instanceof \stdClass) {
+                    $params = [];
+                }
+                if (is_array($params)) {
+                    $existing = is_array($params['_meta'] ?? null) ? $params['_meta'] : [];
+                    $params['_meta'] = array_merge($existing, $this->_meta);
+                }
+            }
+
+            if ($params !== null) {
+                $result['params'] = $params;
             }
 
             if ($this->type === self::TYPE_REQUEST) {
@@ -421,17 +438,24 @@ class RpcMessage
             if ($this->type === self::TYPE_ERROR) {
                 $result['error'] = $this->error;
             } else {
-                $result['result'] = $this->result;
+                $responseResult = $this->result;
+
+                if ($this->_meta !== null) {
+                    if ($responseResult === null || $responseResult instanceof \stdClass) {
+                        $responseResult = [];
+                    }
+                    if (is_array($responseResult)) {
+                        $existing = is_array($responseResult['_meta'] ?? null) ? $responseResult['_meta'] : [];
+                        $responseResult['_meta'] = array_merge($existing, $this->_meta);
+                    }
+                }
+
+                $result['result'] = $responseResult;
             }
 
             if ($this->id !== null) {
                 $result['id'] = $this->id;
             }
-        }
-
-        // Include metadata if present
-        if ($this->_meta !== null) {
-            $result['_meta'] = $this->_meta;
         }
 
         return $result;

--- a/tests/RpcMessageTest.php
+++ b/tests/RpcMessageTest.php
@@ -321,6 +321,64 @@ class RpcMessageTest extends TestCase
         $this->assertArrayHasKey('tools', $message->getResult());
     }
 
+    public function testMetaPreservesStdClassProperties(): void
+    {
+        // P1: stdClass params must not lose existing properties when _meta is added
+        $message = RpcMessage::request('x', (object)['foo' => 'bar']);
+        $message->setMeta('traceId', 'trace-1');
+
+        $array = $message->toArray();
+
+        $this->assertEquals('bar', $array['params']['foo']);
+        $this->assertEquals('trace-1', $array['params']['_meta']['traceId']);
+    }
+
+    public function testMetaPreservesStdClassResultProperties(): void
+    {
+        $message = RpcMessage::response((object)['tools' => []], 1);
+        $message->setMeta('cursor', 'page2');
+
+        $array = $message->toArray();
+
+        $this->assertEquals([], $array['result']['tools']);
+        $this->assertEquals('page2', $array['result']['_meta']['cursor']);
+    }
+
+    public function testFromArrayReadsRootLevelMetaForBackwardCompat(): void
+    {
+        // P2: old wire format with _meta at root level must still be understood
+        $data = [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'test/method',
+            'params' => ['param' => 'value'],
+            '_meta' => ['sessionId' => 'sess_old']
+        ];
+
+        $message = RpcMessage::fromArray($data);
+
+        $this->assertEquals('sess_old', $message->getMeta('sessionId'));
+    }
+
+    public function testFromArrayPrefersNestedMetaOverRootLevel(): void
+    {
+        // When both root-level and nested _meta exist, nested wins
+        $data = [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'test/method',
+            'params' => [
+                'param' => 'value',
+                '_meta' => ['source' => 'nested']
+            ],
+            '_meta' => ['source' => 'root']
+        ];
+
+        $message = RpcMessage::fromArray($data);
+
+        $this->assertEquals('nested', $message->getMeta('source'));
+    }
+
     public function testSetMetaBulkArray(): void
     {
         $message = RpcMessage::request('test/method');

--- a/tests/RpcMessageTest.php
+++ b/tests/RpcMessageTest.php
@@ -275,6 +275,48 @@ class RpcMessageTest extends TestCase
         $this->assertEquals('trace-1', $restored->getMeta('traceId'));
     }
 
+    public function testSetMetaReplacementDoesNotResurrectParsedKeys(): void
+    {
+        // Parse a message with multiple _meta keys
+        $data = [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'test/method',
+            'params' => [
+                'name' => 'foo',
+                '_meta' => ['sessionId' => 'old', 'userId' => 'u1']
+            ]
+        ];
+        $message = RpcMessage::fromArray($data);
+
+        // Full replacement — userId must NOT survive
+        $message->setMeta(['sessionId' => 'new']);
+
+        $array = $message->toArray();
+        $this->assertEquals('new', $array['params']['_meta']['sessionId']);
+        $this->assertArrayNotHasKey('userId', $array['params']['_meta']);
+    }
+
+    public function testSetMetaNullClearsAfterParsing(): void
+    {
+        $data = [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'test/method',
+            'params' => [
+                'name' => 'foo',
+                '_meta' => ['sessionId' => 'sess']
+            ]
+        ];
+        $message = RpcMessage::fromArray($data);
+
+        $message->setMeta(null);
+
+        $this->assertNull($message->getMeta());
+        $array = $message->toArray();
+        $this->assertArrayNotHasKey('_meta', $array['params']);
+    }
+
     public function testMetaMergesWithExistingResultMeta(): void
     {
         $result = [

--- a/tests/RpcMessageTest.php
+++ b/tests/RpcMessageTest.php
@@ -114,15 +114,16 @@ class RpcMessageTest extends TestCase
         $message = RpcMessage::request('test/method', ['param' => 'value']);
         $message->setMeta('sessionId', 'sess_abc123');
         $message->setMeta('userId', 'user_456');
-        
+
         $array = $message->toArray();
-        
-        // Verify _meta is included in serialization
-        $this->assertArrayHasKey('_meta', $array);
+
+        // _meta must be inside params, not at the root level
+        $this->assertArrayNotHasKey('_meta', $array);
+        $this->assertArrayHasKey('_meta', $array['params']);
         $this->assertEquals([
             'sessionId' => 'sess_abc123',
             'userId' => 'user_456'
-        ], $array['_meta']);
+        ], $array['params']['_meta']);
     }
 
     public function testMetaSerializationToJson(): void
@@ -130,16 +131,17 @@ class RpcMessageTest extends TestCase
         $message = RpcMessage::request('test/method', ['param' => 'value']);
         $message->setMeta('sessionId', 'sess_abc123');
         $message->setMeta('userId', 'user_456');
-        
+
         $json = $message->toJson();
         $decoded = json_decode($json, true);
-        
-        // Verify _meta is included in JSON
-        $this->assertArrayHasKey('_meta', $decoded);
+
+        // _meta must be inside params, not at the root level
+        $this->assertArrayNotHasKey('_meta', $decoded);
+        $this->assertArrayHasKey('_meta', $decoded['params']);
         $this->assertEquals([
             'sessionId' => 'sess_abc123',
             'userId' => 'user_456'
-        ], $decoded['_meta']);
+        ], $decoded['params']['_meta']);
     }
 
     public function testMetaDeserializationFromArray(): void
@@ -148,31 +150,36 @@ class RpcMessageTest extends TestCase
             'jsonrpc' => '2.0',
             'id' => 1,
             'method' => 'test/method',
-            'params' => ['param' => 'value'],
-            '_meta' => [
-                'sessionId' => 'sess_abc123',
-                'userId' => 'user_456'
+            'params' => [
+                'param' => 'value',
+                '_meta' => [
+                    'sessionId' => 'sess_abc123',
+                    'userId' => 'user_456'
+                ]
             ]
         ];
-        
+
         $message = RpcMessage::fromArray($data);
-        
-        // Verify metadata was parsed correctly
+
+        // Verify metadata was extracted from params
         $this->assertEquals('sess_abc123', $message->getMeta('sessionId'));
         $this->assertEquals('user_456', $message->getMeta('userId'));
         $this->assertEquals([
             'sessionId' => 'sess_abc123',
             'userId' => 'user_456'
         ], $message->getMeta());
+
+        // params still contains _meta as-is from the wire
+        $this->assertEquals('value', $message->getParams()['param']);
     }
 
     public function testMetaDeserializationFromJson(): void
     {
-        $json = '{"jsonrpc":"2.0","id":1,"method":"test/method","params":{"param":"value"},"_meta":{"sessionId":"sess_abc123","userId":"user_456"}}';
-        
+        $json = '{"jsonrpc":"2.0","id":1,"method":"test/method","params":{"param":"value","_meta":{"sessionId":"sess_abc123","userId":"user_456"}}}';
+
         $message = RpcMessage::fromJson($json);
-        
-        // Verify metadata was parsed correctly
+
+        // Verify metadata was extracted from params
         $this->assertEquals('sess_abc123', $message->getMeta('sessionId'));
         $this->assertEquals('user_456', $message->getMeta('userId'));
         $this->assertEquals([
@@ -203,14 +210,115 @@ class RpcMessageTest extends TestCase
     public function testMetaWithoutMetadata(): void
     {
         $message = RpcMessage::request('test/method');
-        
+
         // Test message without any metadata
         $this->assertNull($message->getMeta());
         $this->assertNull($message->getMeta('anyField'));
-        
-        // Verify serialization doesn't include _meta
+
+        // Verify serialization doesn't include _meta at root or in params
         $array = $message->toArray();
         $this->assertArrayNotHasKey('_meta', $array);
+        if (is_array($array['params'] ?? null)) {
+            $this->assertArrayNotHasKey('_meta', $array['params']);
+        }
+    }
+
+    public function testMetaMergesWithExistingParamsMeta(): void
+    {
+        // Params already contain a _meta with progressToken
+        $params = [
+            '_meta' => ['progressToken' => 'tok-42'],
+            'name' => 'my-tool',
+        ];
+        $message = RpcMessage::request('tools/call', $params);
+
+        // setMeta adds extra fields via the public API
+        $message->setMeta('sessionId', 'sess_abc');
+
+        $array = $message->toArray();
+
+        // Both the original progressToken and the added sessionId must be present
+        $this->assertEquals('tok-42', $array['params']['_meta']['progressToken']);
+        $this->assertEquals('sess_abc', $array['params']['_meta']['sessionId']);
+    }
+
+    public function testMetaSetViaApiOverridesExistingParamsMetaKey(): void
+    {
+        // Params already have a _meta key that will also be set via setMeta
+        $params = [
+            '_meta' => ['progressToken' => 'old-token'],
+            'name' => 'my-tool',
+        ];
+        $message = RpcMessage::request('tools/call', $params);
+
+        // Override the same key via the public API — setMeta wins
+        $message->setMeta('progressToken', 'new-token');
+
+        $array = $message->toArray();
+        $this->assertEquals('new-token', $array['params']['_meta']['progressToken']);
+    }
+
+    public function testMetaMergeRoundTrip(): void
+    {
+        // Build a request whose params already contain _meta.progressToken
+        $params = [
+            '_meta' => ['progressToken' => 'tok-99'],
+            'name' => 'search',
+        ];
+        $message = RpcMessage::request('tools/call', $params);
+        $message->setMeta('traceId', 'trace-1');
+
+        // Serialize and parse back
+        $restored = RpcMessage::fromJson($message->toJson());
+
+        $this->assertEquals('tok-99', $restored->getMeta('progressToken'));
+        $this->assertEquals('trace-1', $restored->getMeta('traceId'));
+    }
+
+    public function testMetaMergesWithExistingResultMeta(): void
+    {
+        $result = [
+            '_meta' => ['cursor' => 'page2'],
+            'tools' => [],
+        ];
+        $message = RpcMessage::response($result, 1);
+
+        $message->setMeta('extra', 'value');
+
+        $array = $message->toArray();
+
+        $this->assertEquals('page2', $array['result']['_meta']['cursor']);
+        $this->assertEquals('value', $array['result']['_meta']['extra']);
+    }
+
+    public function testMetaInResponseResult(): void
+    {
+        // Verify _meta is nested inside result for responses
+        $message = RpcMessage::response(['tools' => []], 1);
+        $message->setMeta('serverTime', 1640995200);
+
+        $array = $message->toArray();
+
+        $this->assertArrayNotHasKey('_meta', $array);
+        $this->assertArrayHasKey('_meta', $array['result']);
+        $this->assertEquals(['serverTime' => 1640995200], $array['result']['_meta']);
+    }
+
+    public function testMetaDeserializationFromResponse(): void
+    {
+        $data = [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'result' => [
+                'tools' => [],
+                '_meta' => ['serverTime' => 1640995200]
+            ]
+        ];
+
+        $message = RpcMessage::fromArray($data);
+
+        $this->assertEquals(1640995200, $message->getMeta('serverTime'));
+        $this->assertArrayHasKey('tools', $message->getResult());
     }
 
     public function testSetMetaBulkArray(): void


### PR DESCRIPTION
…`params`