### PR TITLE
Preserve MCP JSON object shapes in RPC messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,16 +214,17 @@ $listToolsChannel->setOnMcpMessageCallback(function (RpcMessage $message, McpCha
     echo "Received MCP Message (ID: {$message->getId()}, Type: {$message->getType()})\n";
 
     if ($message->isResponse() && $message->getId() === $channel->getRpcMessage()->getId()) { // Response to tools/list request
-        if ($message->getResult() && isset($message->getResult()['tools'])) {
+        $result = $message->getResult();
+        if ($result instanceof \stdClass && isset($result->tools)) {
             echo "Available Tools:\n";
-            foreach ($message->getResult()['tools'] as $tool) {
+            foreach ($result->tools as $tool) {
                 // Build function-like definition with parameters
-                $functionDef = $tool['name'];
-                if (isset($tool['inputSchema']) && isset($tool['inputSchema']['properties'])) {
+                $functionDef = $tool->name;
+                if (isset($tool->inputSchema) && isset($tool->inputSchema->properties)) {
                     $params = [];
-                    foreach ($tool['inputSchema']['properties'] as $paramName => $paramProps) {
-                        $type = $paramProps['type'] ?? 'mixed';
-                        $required = in_array($paramName, $tool['inputSchema']['required'] ?? []) ? '' : '?';
+                    foreach ($tool->inputSchema->properties as $paramName => $paramProps) {
+                        $type = $paramProps->type ?? 'mixed';
+                        $required = in_array($paramName, $tool->inputSchema->required ?? [], true) ? '' : '?';
                         $params[] = "{$type}{$required} \\${$paramName}";
                     }
                     $functionDef .= "(" . implode(', ', $params) . ")";
@@ -232,20 +233,22 @@ $listToolsChannel->setOnMcpMessageCallback(function (RpcMessage $message, McpCha
                 }
 
                 echo "- Name: {$functionDef}\n";
-                echo "  Description: ".($tool['description'] ?? 'No description available')."\n";
+                echo "  Description: ".($tool->description ?? 'No description available')."\n";
 
                 // Optionally print inputSchema
-                // echo "  Input Schema: " . json_encode($tool['inputSchema']) . "\n";
+                // echo "  Input Schema: " . json_encode($tool->inputSchema) . "\n";
             }
-        } elseif ($message->getError()) {
-            echo "Error listing tools: {$message->getError()['message']} (Code: {$message->getError()['code']})\n";
+        } elseif ($message->isError()) {
+            $error = $message->getError();
+            echo "Error listing tools: {$error->message} (Code: {$error->code})\n";
         } else {
             echo "Unexpected response format for tools/list\n";
         }
 
         return false; // abort connection
     } else if ($message->isError()) {
-        echo "Error during tools listing: {$message->getError()['message']} (Code: {$message->getError()['code']})\n";
+        $error = $message->getError();
+        echo "Error during tools listing: {$error->message} (Code: {$error->code})\n";
     }
 });
 

--- a/examples/mcp_list_tools.php
+++ b/examples/mcp_list_tools.php
@@ -23,16 +23,17 @@ $listToolsChannel->setOnMcpMessageCallback(function (RpcMessage $message, McpCha
     echo "Received MCP Message (ID: {$message->getId()}, Type: {$message->getType()})\n";
 
     if ($message->isResponse() && $message->getId() === $channel->getRpcMessage()->getId()) { // Response to tools/list request
-        if ($message->getResult() && isset($message->getResult()['tools'])) {
+        $result = $message->getResult();
+        if ($result instanceof \stdClass && isset($result->tools)) {
             echo "Available Tools:\n";
-            foreach ($message->getResult()['tools'] as $tool) {
+            foreach ($result->tools as $tool) {
                 // Build function-like definition with parameters
-                $functionDef = $tool['name'];
-                if (isset($tool['inputSchema']) && isset($tool['inputSchema']['properties'])) {
+                $functionDef = $tool->name;
+                if (isset($tool->inputSchema) && isset($tool->inputSchema->properties)) {
                     $params = [];
-                    foreach ($tool['inputSchema']['properties'] as $paramName => $paramProps) {
-                        $type = $paramProps['type'] ?? 'mixed';
-                        $required = in_array($paramName, $tool['inputSchema']['required'] ?? []) ? '' : '?';
+                    foreach ($tool->inputSchema->properties as $paramName => $paramProps) {
+                        $type = $paramProps->type ?? 'mixed';
+                        $required = in_array($paramName, $tool->inputSchema->required ?? [], true) ? '' : '?';
                         $params[] = "{$type}{$required} \${$paramName}";
                     }
                     $functionDef .= "(" . implode(', ', $params) . ")";
@@ -41,20 +42,22 @@ $listToolsChannel->setOnMcpMessageCallback(function (RpcMessage $message, McpCha
                 }
 
                 echo "- Name: {$functionDef}\n";
-                echo "  Description: ".($tool['description'] ?? 'No description available')."\n";
+                echo "  Description: ".($tool->description ?? 'No description available')."\n";
 
                 // Optionally print inputSchema
-                // echo "  Input Schema: " . json_encode($tool['inputSchema']) . "\n";
+                // echo "  Input Schema: " . json_encode($tool->inputSchema) . "\n";
             }
-        } elseif ($message->getError()) {
-            echo "Error listing tools: {$message->getError()['message']} (Code: {$message->getError()['code']})\n";
+        } elseif ($message->isError()) {
+            $error = $message->getError();
+            echo "Error listing tools: {$error->message} (Code: {$error->code})\n";
         } else {
             echo "Unexpected response format for tools/list\n";
         }
 
         return false; // abort connection
     } else if ($message->isError()) {
-        echo "Error during tools listing: {$message->getError()['message']} (Code: {$message->getError()['code']})\n";
+        $error = $message->getError();
+        echo "Error during tools listing: {$error->message} (Code: {$error->code})\n";
     }
 });
 

--- a/src/Mcp/RpcMessage.php
+++ b/src/Mcp/RpcMessage.php
@@ -61,10 +61,8 @@ class RpcMessage
 
     /**
      * Error for error responses
-     *
-     * @var array<string, mixed>|null
      */
-    protected ?array $error = null;
+    protected mixed $error = null;
 
     /**
      * Message ID for requests and responses (null for notifications)
@@ -325,13 +323,12 @@ class RpcMessage
     {
         $rpcMessage = new self();
         $rpcMessage->type = self::TYPE_ERROR;
-        $rpcMessage->error = [
-            'code' => $code,
-            'message' => $message
-        ];
+        $rpcMessage->error = new \stdClass();
+        $rpcMessage->error->code = $code;
+        $rpcMessage->error->message = $message;
 
         if ($data !== null) {
-            $rpcMessage->error['data'] = $data;
+            $rpcMessage->error->data = $data;
         }
 
         $rpcMessage->id = $id;
@@ -344,50 +341,104 @@ class RpcMessage
      */
     public static function fromJson(string $json): self
     {
-        $data = json_decode($json, true);
-        if ($data === null) {
-            throw new \InvalidArgumentException('Invalid JSON: ' . json_last_error_msg());
+        try {
+            $data = json_decode($json, false, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \InvalidArgumentException('Invalid JSON: ' . $e->getMessage(), 0, $e);
         }
 
-        return self::fromArray($data);
+        if (!$data instanceof \stdClass) {
+            throw new \InvalidArgumentException('Invalid JSON-RPC message: ' . $json);
+        }
+
+        return self::fromDecodedJson($data);
     }
 
     /**
-     * Parse array into RpcMessage
-     *
-     * @param array<string, mixed> $data
+     * Parse a decoded JSON-RPC object into RpcMessage
      */
-    public static function fromArray(array $data): self
+    public static function fromDecodedJson(\stdClass $data): self
     {
         $message = new self();
 
-        // Verify JSON-RPC version
-        if (!isset($data['jsonrpc']) || $data['jsonrpc'] !== '2.0') {
+        if (!property_exists($data, 'jsonrpc') || $data->jsonrpc !== '2.0') {
             throw new \InvalidArgumentException('Invalid or no JSON-RPC version in message: ' . json_encode($data));
         }
 
-        // Determine message type
-        if (isset($data['method'])) {
-            if (isset($data['id'])) {
+        $hasMethod = property_exists($data, 'method');
+        $hasResult = property_exists($data, 'result');
+        $hasError = property_exists($data, 'error');
+
+        if ($hasMethod) {
+            if ($hasResult || $hasError) {
+                throw new \InvalidArgumentException('Invalid JSON-RPC request message: ' . json_encode($data));
+            }
+
+            if (!is_string($data->method) || $data->method === '') {
+                throw new \InvalidArgumentException('Invalid JSON-RPC method in message: ' . json_encode($data));
+            }
+
+            if (property_exists($data, 'params') && !is_array($data->params) && !$data->params instanceof \stdClass) {
+                throw new \InvalidArgumentException('Invalid JSON-RPC params in message: ' . json_encode($data));
+            }
+
+            if (property_exists($data, 'id')) {
+                self::assertValidId($data->id, $data);
                 $message->type = self::TYPE_REQUEST;
-                $message->id = $data['id'];
+                $message->id = $data->id;
             } else {
                 $message->type = self::TYPE_NOTIFICATION;
             }
-            $message->method = $data['method'];
-            $message->params = $data['params'] ?? null;
+            $message->method = $data->method;
+            $message->params = property_exists($data, 'params') ? $data->params : null;
         } else {
-            if (isset($data['error'])) {
-                $message->type = self::TYPE_ERROR;
-                $message->error = $data['error'];
-            } else {
-                $message->type = self::TYPE_RESPONSE;
-                $message->result = $data['result'] ?? null;
+            if ($hasResult === $hasError) {
+                throw new \InvalidArgumentException('Invalid JSON-RPC response message: ' . json_encode($data));
             }
-            $message->id = $data['id'] ?? null;
+
+            if ($hasError) {
+                self::assertValidError($data->error, $data);
+                $message->type = self::TYPE_ERROR;
+                $message->error = $data->error;
+            } else {
+                if (!property_exists($data, 'id')) {
+                    throw new \InvalidArgumentException('Invalid JSON-RPC response message: ' . json_encode($data));
+                }
+                $message->type = self::TYPE_RESPONSE;
+                $message->result = $data->result;
+            }
+
+            if (property_exists($data, 'id')) {
+                self::assertValidId($data->id, $data);
+                $message->id = $data->id;
+            }
         }
 
         return $message;
+    }
+
+    private static function assertValidId(mixed $id, \stdClass $data): void
+    {
+        if ($id === null || is_string($id) || is_int($id)) {
+            return;
+        }
+
+        throw new \InvalidArgumentException('Invalid JSON-RPC id in message: ' . json_encode($data));
+    }
+
+    private static function assertValidError(mixed $error, \stdClass $data): void
+    {
+        if (
+            $error instanceof \stdClass &&
+            property_exists($error, 'code') &&
+            is_int($error->code) &&
+            property_exists($error, 'message') &&
+            is_string($error->message)
+        ) {
+            return;
+        }
+
+        throw new \InvalidArgumentException('Invalid JSON-RPC error in message: ' . json_encode($data));
     }
 
     /**
@@ -473,10 +524,8 @@ class RpcMessage
 
     /**
      * Get error
-     *
-     * @return array<string, mixed>|null
      */
-    public function getError(): ?array
+    public function getError(): mixed
     {
         return $this->error;
     }
@@ -528,11 +577,15 @@ class RpcMessage
 
     public function getErrorMessage(): string
     {
-        return $this->error['message'] ?? '';
+        $message = $this->error instanceof \stdClass && property_exists($this->error, 'message') ? $this->error->message : '';
+
+        return is_string($message) ? $message : '';
     }
 
     public function getErrorCode(): int
     {
-        return $this->error['code'] ?? 0;
+        $code = $this->error instanceof \stdClass && property_exists($this->error, 'code') ? $this->error->code : 0;
+
+        return is_int($code) ? $code : 0;
     }
 }

--- a/src/McpChannel.php
+++ b/src/McpChannel.php
@@ -373,7 +373,11 @@ class McpChannel extends HttpChannel
 
                     $message = RpcMessage::fromDecodedJson($item);
                     $messageResult = $this->onMcpMessage($message, $manager);
-                    if ($messageResult === false || $message->isError()) {
+                    if ($messageResult === false) {
+                        return false;
+                    }
+
+                    if ($message->isError()) {
                         // if the message is an error the overall result will be false
                         $res = false;
                     }

--- a/src/McpChannel.php
+++ b/src/McpChannel.php
@@ -350,18 +350,28 @@ class McpChannel extends HttpChannel
      */
     protected function processJsonMessage(string $json, Manager $manager): ?bool
     {
-        $data = json_decode($json, true);
-        if ($data === null) {
+        try {
+            $data = json_decode($json, false, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
             // Invalid JSON, ignore
             return null;
         }
 
-        if (is_array($data) && isset($data[0])) {
+        if (is_array($data)) {
             // Batch of messages
+            if (empty($data)) {
+                $this->onException(new \InvalidArgumentException('Invalid JSON-RPC batch: empty array'));
+                return null;
+            }
+
             $res = true;
             foreach ($data as $item) {
                 try {
-                    $message = RpcMessage::fromArray($item);
+                    if (!$item instanceof \stdClass) {
+                        throw new \InvalidArgumentException('Invalid JSON-RPC message: ' . json_encode($item));
+                    }
+
+                    $message = RpcMessage::fromDecodedJson($item);
                     $res = $res && $this->onMcpMessage($message, $manager);
                     if ($message->isError()) {
                         // if the message is an error the overall result will be false
@@ -369,14 +379,19 @@ class McpChannel extends HttpChannel
                     }
                 } catch (\Exception $e) {
                     // Skip invalid messages
+                    $res = false;
                     $this->onException($e);
                 }
             }
             return $res;
         } else {
+            if (!$data instanceof \stdClass) {
+                return null;
+            }
+
             // Single message
             try {
-                $message = RpcMessage::fromArray($data);
+                $message = RpcMessage::fromDecodedJson($data);
                 $res = $this->onMcpMessage($message, $manager);
                 if ($message->isError()) {
                     // if the message is an error, stop processing
@@ -450,14 +465,12 @@ class McpChannel extends HttpChannel
             if ($message->isError()) {
                 // Propagate error to caller via exception
                 throw new \RuntimeException('MCP initialization error: ' .
-                    ($message->getError()['message'] ?? 'Unknown error') .
-                    ' (Code: ' . ($message->getError()['code'] ?? 'unknown') . ')');
+                    ($message->getErrorMessage() ?: 'Unknown error') .
+                    ' (Code: ' . ($message->getErrorCode() ?: 'unknown') . ')');
             }
 
             if ($message->isResponse() && $message->getId() == $channel->getRpcMessage()->getId()) {
-                if ($message->getResult()) {
-                    $result = $message->getResult();
-
+                if ($message->getResult() !== null) {
                     // update the main channel's session ID
                     $mainChannel->setSessionId($channel->getSessionId());
 

--- a/src/McpChannel.php
+++ b/src/McpChannel.php
@@ -372,8 +372,8 @@ class McpChannel extends HttpChannel
                     }
 
                     $message = RpcMessage::fromDecodedJson($item);
-                    $res = $res && $this->onMcpMessage($message, $manager);
-                    if ($message->isError()) {
+                    $messageResult = $this->onMcpMessage($message, $manager);
+                    if ($messageResult === false || $message->isError()) {
                         // if the message is an error the overall result will be false
                         $res = false;
                     }

--- a/src/Sse/SseTrait.php
+++ b/src/Sse/SseTrait.php
@@ -63,7 +63,7 @@ trait SseTrait
     /**
      * Sets whether the channel is streamable
      */
-    abstract public function setStreamable(bool $streamable): void;
+    abstract public function setStreamable(bool $streamable = true): void;
 
     /**
      * Gets the stream object for buffer manipulation

--- a/tests/Integration/McpIntegrationTest.php
+++ b/tests/Integration/McpIntegrationTest.php
@@ -9,6 +9,7 @@ use Maurice\Multicurl\McpChannel;
 use Maurice\Multicurl\Mcp\RpcMessage;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
+use stdClass;
 
 /**
  * Real integration tests for MCP (Model Context Protocol) functionality
@@ -73,10 +74,10 @@ class McpIntegrationTest extends TestCase
 
         // If we got a successful response, validate it
         if ($initResponse !== null) {
-            $this->assertIsArray($initResponse, 'Initialize response should be an array');
-            $this->assertArrayHasKey('protocolVersion', $initResponse, 'Response should contain protocol version');
-            $this->assertArrayHasKey('capabilities', $initResponse, 'Response should contain server capabilities');
-            $this->assertArrayHasKey('serverInfo', $initResponse, 'Response should contain server info');
+            $this->assertInstanceOf(stdClass::class, $initResponse, 'Initialize response should be an object');
+            $this->assertTrue(property_exists($initResponse, 'protocolVersion'), 'Response should contain protocol version');
+            $this->assertTrue(property_exists($initResponse, 'capabilities'), 'Response should contain server capabilities');
+            $this->assertTrue(property_exists($initResponse, 'serverInfo'), 'Response should contain server info');
         }
 
         $this->assertTrue(true, 'MCP initialization integration test completed');
@@ -111,7 +112,7 @@ class McpIntegrationTest extends TestCase
             if ($message->isResponse() && !$message->isError() && $message->getResult() !== null) {
                 $result = $message->getResult();
                 // Check if this is a tools/list response (has 'tools' key)
-                if (is_array($result) && array_key_exists('tools', $result)) {
+                if ($result instanceof stdClass && property_exists($result, 'tools')) {
                     $toolsResponse = $result;
                 }
             }
@@ -136,15 +137,16 @@ class McpIntegrationTest extends TestCase
 
         // If we got a successful response, validate it
         if ($toolsResponse !== null) {
-            $this->assertIsArray($toolsResponse, 'Tools response should be an array');
-            $this->assertArrayHasKey('tools', $toolsResponse, 'Response should contain tools array');
-            $this->assertIsArray($toolsResponse['tools'], 'Tools should be an array');
+            $this->assertInstanceOf(stdClass::class, $toolsResponse, 'Tools response should be an object');
+            $this->assertTrue(property_exists($toolsResponse, 'tools'), 'Response should contain tools array');
+            $this->assertIsArray($toolsResponse->tools, 'Tools should be an array');
 
             // Verify tool structure if tools are present
-            if (!empty($toolsResponse['tools'])) {
-                $firstTool = $toolsResponse['tools'][0];
-                $this->assertArrayHasKey('name', $firstTool, 'Tool should have a name');
-                $this->assertArrayHasKey('description', $firstTool, 'Tool should have a description');
+            if (!empty($toolsResponse->tools)) {
+                $firstTool = $toolsResponse->tools[0];
+                $this->assertInstanceOf(stdClass::class, $firstTool, 'Tool should be an object');
+                $this->assertTrue(property_exists($firstTool, 'name'), 'Tool should have a name');
+                $this->assertTrue(property_exists($firstTool, 'description'), 'Tool should have a description');
             }
         }
 
@@ -178,7 +180,7 @@ class McpIntegrationTest extends TestCase
             if ($message->isResponse() && !$message->isError() && $message->getResult() !== null) {
                 $result = $message->getResult();
                 // Check if this is a prompts/list response (has 'prompts' key)
-                if (is_array($result) && array_key_exists('prompts', $result)) {
+                if ($result instanceof stdClass && property_exists($result, 'prompts')) {
                     $promptsResponse = $result;
                 }
             }
@@ -203,15 +205,16 @@ class McpIntegrationTest extends TestCase
 
         // If we got a successful response, validate it
         if ($promptsResponse !== null) {
-            $this->assertIsArray($promptsResponse, 'Prompts response should be an array');
-            $this->assertArrayHasKey('prompts', $promptsResponse, 'Response should contain prompts array');
-            $this->assertIsArray($promptsResponse['prompts'], 'Prompts should be an array');
+            $this->assertInstanceOf(stdClass::class, $promptsResponse, 'Prompts response should be an object');
+            $this->assertTrue(property_exists($promptsResponse, 'prompts'), 'Response should contain prompts array');
+            $this->assertIsArray($promptsResponse->prompts, 'Prompts should be an array');
 
             // Verify prompt structure if prompts are present
-            if (!empty($promptsResponse['prompts'])) {
-                $firstPrompt = $promptsResponse['prompts'][0];
-                $this->assertArrayHasKey('name', $firstPrompt, 'Prompt should have a name');
-                $this->assertArrayHasKey('description', $firstPrompt, 'Prompt should have a description');
+            if (!empty($promptsResponse->prompts)) {
+                $firstPrompt = $promptsResponse->prompts[0];
+                $this->assertInstanceOf(stdClass::class, $firstPrompt, 'Prompt should be an object');
+                $this->assertTrue(property_exists($firstPrompt, 'name'), 'Prompt should have a name');
+                $this->assertTrue(property_exists($firstPrompt, 'description'), 'Prompt should have a description');
             }
         }
 
@@ -302,9 +305,9 @@ class McpIntegrationTest extends TestCase
             $channel->setOnMcpMessageCallback(function (RpcMessage $message, McpChannel $channel, Manager $manager) use (&$responses, $requestId): bool {
                 if ($message->isResponse()) {
                     $result = $message->getResult();
-                    if (is_array($result) && (
-                        array_key_exists('tools', $result) ||
-                        array_key_exists('prompts', $result)
+                    if ($result instanceof stdClass && (
+                        property_exists($result, 'tools') ||
+                        property_exists($result, 'prompts')
                     )) {
                         $responses[$requestId] = $result;
                         return false; // Stop processing messages
@@ -513,7 +516,7 @@ class McpIntegrationTest extends TestCase
             if ($message->isResponse() && !$message->isError() && $message->getResult() !== null) {
                 $result = $message->getResult();
                 // Check if this is a tools/list response (has 'tools' key)
-                if (is_array($result) && array_key_exists('tools', $result)) {
+                if ($result instanceof stdClass && property_exists($result, 'tools')) {
                     $finalSessionId = $channel->getSessionId();
                 }
             }
@@ -613,7 +616,7 @@ class McpIntegrationTest extends TestCase
 
             if ($message->isResponse() && !$message->isError() && $message->getResult() !== null) {
                 $result = $message->getResult();
-                if (is_array($result) && array_key_exists('tools', $result)) {
+                if ($result instanceof stdClass && property_exists($result, 'tools')) {
                     $finalResponse = $result;
                 }
             }

--- a/tests/McpChannelTest.php
+++ b/tests/McpChannelTest.php
@@ -354,6 +354,26 @@ class McpChannelTest extends TestCase
         $this->assertIsArray($messages[1]->getResult()->items);
     }
 
+    public function testProcessJsonMessageStopsBatchWhenCallbackReturnsFalse(): void
+    {
+        $channel = new McpChannel('file:///dev/null', RpcMessage::toolsListRequest());
+        $messages = [];
+
+        $channel->setOnMcpMessageCallback(function (RpcMessage $message) use (&$messages): bool {
+            $messages[] = $message;
+            return false;
+        });
+
+        $result = $this->processJsonMessage(
+            $channel,
+            '[{"jsonrpc":"2.0","id":"first","result":{}},{"jsonrpc":"2.0","id":"second","result":{}}]'
+        );
+
+        $this->assertFalse($result);
+        $this->assertCount(1, $messages);
+        $this->assertSame('first', $messages[0]->getId());
+    }
+
     public function testProcessJsonMessagePreservesErrorJsonShape(): void
     {
         $channel = new McpChannel('file:///dev/null', RpcMessage::toolsListRequest());

--- a/tests/McpChannelTest.php
+++ b/tests/McpChannelTest.php
@@ -442,6 +442,34 @@ class McpChannelTest extends TestCase
         $this->assertInstanceOf(\InvalidArgumentException::class, $exception);
     }
 
+    public function testProcessJsonMessageContinuesBatchAfterInvalidItem(): void
+    {
+        $channel = new McpChannel('file:///dev/null', RpcMessage::toolsListRequest());
+        $messages = [];
+        $exception = null;
+
+        $channel->setOnMcpMessageCallback(function (RpcMessage $message) use (&$messages): bool {
+            $messages[] = $message;
+            return true;
+        });
+        $channel->setOnExceptionCallback(function (\Exception $caught) use (&$exception): void {
+            $exception = $caught;
+        });
+
+        $result = $this->processJsonMessage(
+            $channel,
+            '[{"jsonrpc":"2.0","method":null,"id":"invalid"},{"jsonrpc":"2.0","id":"valid","result":{"ok":true}}]'
+        );
+
+        $this->assertFalse($result);
+        $this->assertCount(1, $messages);
+        $this->assertSame('valid', $messages[0]->getId());
+        $this->assertTrue($messages[0]->isResponse());
+        $this->assertInstanceOf(stdClass::class, $messages[0]->getResult());
+        $this->assertTrue($messages[0]->getResult()->ok);
+        $this->assertInstanceOf(\InvalidArgumentException::class, $exception);
+    }
+
     public function testProcessJsonMessageIgnoresInvalidJson(): void
     {
         $channel = new McpChannel('file:///dev/null', RpcMessage::toolsListRequest());

--- a/tests/McpChannelTest.php
+++ b/tests/McpChannelTest.php
@@ -8,6 +8,7 @@ use Maurice\Multicurl\Manager;
 use Maurice\Multicurl\McpChannel;
 use Maurice\Multicurl\Mcp\RpcMessage;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 /**
  * Tests for the McpChannel class
@@ -304,6 +305,157 @@ class McpChannelTest extends TestCase
         $this->assertTrue(true, 'JSON serialization/deserialization working correctly');
     }
 
+    public function testProcessJsonMessagePreservesResultJsonShape(): void
+    {
+        $channel = new McpChannel('file:///dev/null', RpcMessage::toolsListRequest());
+        $messages = [];
+
+        $channel->setOnMcpMessageCallback(function (RpcMessage $message, McpChannel $channel, Manager $manager) use (&$messages): bool {
+            $messages[] = $message;
+            return true;
+        });
+
+        $result = $this->processJsonMessage(
+            $channel,
+            '{"jsonrpc":"2.0","id":"1","result":{"tools":[{"name":"test","inputSchema":{"type":"object","properties":{},"required":[]}}]}}'
+        );
+
+        $this->assertTrue($result);
+        $this->assertCount(1, $messages);
+
+        $value = $messages[0]->getResult();
+        $this->assertInstanceOf(stdClass::class, $value);
+        $this->assertIsArray($value->tools);
+        $this->assertInstanceOf(stdClass::class, $value->tools[0]);
+        $this->assertInstanceOf(stdClass::class, $value->tools[0]->inputSchema->properties);
+        $this->assertIsArray($value->tools[0]->inputSchema->required);
+    }
+
+    public function testProcessJsonMessagePreservesBatchJsonShapes(): void
+    {
+        $channel = new McpChannel('file:///dev/null', RpcMessage::toolsListRequest());
+        $messages = [];
+
+        $channel->setOnMcpMessageCallback(function (RpcMessage $message, McpChannel $channel, Manager $manager) use (&$messages): bool {
+            $messages[] = $message;
+            return true;
+        });
+
+        $result = $this->processJsonMessage(
+            $channel,
+            '[{"jsonrpc":"2.0","id":"1","result":{"schema":{"properties":{}}}},{"jsonrpc":"2.0","id":"2","result":{"items":[]}}]'
+        );
+
+        $this->assertTrue($result);
+        $this->assertCount(2, $messages);
+        $this->assertSame('1', $messages[0]->getId());
+        $this->assertSame('2', $messages[1]->getId());
+        $this->assertInstanceOf(stdClass::class, $messages[0]->getResult()->schema->properties);
+        $this->assertIsArray($messages[1]->getResult()->items);
+    }
+
+    public function testProcessJsonMessagePreservesErrorJsonShape(): void
+    {
+        $channel = new McpChannel('file:///dev/null', RpcMessage::toolsListRequest());
+        $messages = [];
+
+        $channel->setOnMcpMessageCallback(function (RpcMessage $message, McpChannel $channel, Manager $manager) use (&$messages): bool {
+            $messages[] = $message;
+            return true;
+        });
+
+        $result = $this->processJsonMessage(
+            $channel,
+            '{"jsonrpc":"2.0","id":"1","error":{"code":-32602,"message":"Invalid params","data":{"details":{},"items":[]}}}'
+        );
+
+        $this->assertFalse($result);
+        $this->assertCount(1, $messages);
+
+        $error = $messages[0]->getError();
+        $this->assertInstanceOf(stdClass::class, $error);
+        $this->assertInstanceOf(stdClass::class, $error->data->details);
+        $this->assertIsArray($error->data->items);
+    }
+
+    public function testProcessJsonMessageRejectsEmptyBatch(): void
+    {
+        $channel = new McpChannel('file:///dev/null', RpcMessage::toolsListRequest());
+        $callbackCalled = false;
+        $exception = null;
+
+        $channel->setOnMcpMessageCallback(function () use (&$callbackCalled): bool {
+            $callbackCalled = true;
+            return true;
+        });
+        $channel->setOnExceptionCallback(function (\Exception $caught) use (&$exception): void {
+            $exception = $caught;
+        });
+
+        $this->assertNull($this->processJsonMessage($channel, '[]'));
+        $this->assertFalse($callbackCalled);
+        $this->assertInstanceOf(\InvalidArgumentException::class, $exception);
+        $this->assertStringContainsString('batch', $exception->getMessage());
+    }
+
+    public function testProcessJsonMessageRejectsInvalidEnvelope(): void
+    {
+        $channel = new McpChannel('file:///dev/null', RpcMessage::toolsListRequest());
+        $callbackCalled = false;
+        $exception = null;
+
+        $channel->setOnMcpMessageCallback(function () use (&$callbackCalled): bool {
+            $callbackCalled = true;
+            return true;
+        });
+        $channel->setOnExceptionCallback(function (\Exception $caught) use (&$exception): void {
+            $exception = $caught;
+        });
+
+        $this->assertNull($this->processJsonMessage($channel, '{"jsonrpc":"2.0","method":null,"id":"1"}'));
+        $this->assertFalse($callbackCalled);
+        $this->assertInstanceOf(\InvalidArgumentException::class, $exception);
+        $this->assertStringContainsString('method', $exception->getMessage());
+    }
+
+    public function testProcessJsonMessageReturnsFalseForInvalidBatchItem(): void
+    {
+        $channel = new McpChannel('file:///dev/null', RpcMessage::toolsListRequest());
+        $messages = [];
+        $exception = null;
+
+        $channel->setOnMcpMessageCallback(function (RpcMessage $message) use (&$messages): bool {
+            $messages[] = $message;
+            return true;
+        });
+        $channel->setOnExceptionCallback(function (\Exception $caught) use (&$exception): void {
+            $exception = $caught;
+        });
+
+        $result = $this->processJsonMessage(
+            $channel,
+            '[{"jsonrpc":"2.0","id":"1","result":{}},{"jsonrpc":"2.0","method":null,"id":"2"}]'
+        );
+
+        $this->assertFalse($result);
+        $this->assertCount(1, $messages);
+        $this->assertInstanceOf(\InvalidArgumentException::class, $exception);
+    }
+
+    public function testProcessJsonMessageIgnoresInvalidJson(): void
+    {
+        $channel = new McpChannel('file:///dev/null', RpcMessage::toolsListRequest());
+        $callbackCalled = false;
+
+        $channel->setOnMcpMessageCallback(function () use (&$callbackCalled): bool {
+            $callbackCalled = true;
+            return true;
+        });
+
+        $this->assertNull($this->processJsonMessage($channel, '{'));
+        $this->assertFalse($callbackCalled);
+    }
+
     public function testMcpSessionIdManagement(): void
     {
         // Test session ID management in McpChannel
@@ -322,6 +474,13 @@ class McpChannelTest extends TestCase
         $this->assertNull($channel->getSessionId());
 
         $this->assertTrue(true, 'Session ID management working correctly');
+    }
+
+    private function processJsonMessage(McpChannel $channel, string $json): ?bool
+    {
+        $method = new \ReflectionMethod(McpChannel::class, 'processJsonMessage');
+
+        return $method->invoke($channel, $json, new Manager());
     }
 
     public function testMcpMessageTypes(): void

--- a/tests/RpcMessageTest.php
+++ b/tests/RpcMessageTest.php
@@ -39,7 +39,8 @@ class RpcMessageTest extends TestCase
         $this->assertTrue($message->isError());
         $this->assertSame(-32603, $message->getErrorCode());
         $this->assertSame('Internal error', $message->getErrorMessage());
-        $this->assertSame(['detail' => 'x'], $message->getError()['data']);
+        $this->assertInstanceOf(stdClass::class, $message->getError());
+        $this->assertSame(['detail' => 'x'], $message->getError()->data);
         $this->assertSame('9', $message->getId());
     }
 
@@ -50,6 +51,9 @@ class RpcMessageTest extends TestCase
         $this->assertTrue($message->isRequest());
         $this->assertSame('tools/list', $message->getMethod());
         $this->assertInstanceOf(stdClass::class, $message->getParams());
+
+        $payload = json_decode($message->toJson(), false, 512, JSON_THROW_ON_ERROR);
+        $this->assertInstanceOf(stdClass::class, $payload->params);
     }
 
     public function testToolsListRequestAcceptsCustomParams(): void
@@ -104,6 +108,17 @@ class RpcMessageTest extends TestCase
         $this->assertArrayNotHasKey('outputSchema', $message->getParams());
     }
 
+    public function testToolsCallRequestUsesEmptyObjectArgumentsWhenNotProvided(): void
+    {
+        $message = RpcMessage::toolsCallRequest('my_tool');
+
+        $this->assertInstanceOf(stdClass::class, $message->getParams()['arguments']);
+
+        $payload = json_decode($message->toJson(), false, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('my_tool', $payload->params->name);
+        $this->assertInstanceOf(stdClass::class, $payload->params->arguments);
+    }
+
     public function testInitializeRequestUsesDefaultClientInfoAndEmptyCapabilitiesObject(): void
     {
         $message = RpcMessage::initializeRequest();
@@ -119,6 +134,7 @@ class RpcMessageTest extends TestCase
             $params['clientInfo']
         );
         $this->assertInstanceOf(stdClass::class, $params['capabilities']);
+        $this->assertStringContainsString('"capabilities":{}', $message->toJson());
     }
 
     public function testInitializeRequestKeepsProvidedClientInfoAndCapabilities(): void
@@ -146,6 +162,14 @@ class RpcMessageTest extends TestCase
         RpcMessage::fromJson('{');
     }
 
+    public function testFromJsonRejectsTopLevelArray(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid JSON-RPC message');
+
+        RpcMessage::fromJson('[{"jsonrpc":"2.0","method":"tools/list","id":"1"}]');
+    }
+
     public function testFromJsonParsesRequestMessage(): void
     {
         $message = RpcMessage::fromJson(
@@ -155,70 +179,227 @@ class RpcMessageTest extends TestCase
         $this->assertTrue($message->isRequest());
         $this->assertSame('tools/list', $message->getMethod());
         $this->assertSame('1', $message->getId());
-        $this->assertSame(['foo' => 'bar'], $message->getParams());
+        $this->assertInstanceOf(stdClass::class, $message->getParams());
+        $this->assertSame('bar', $message->getParams()->foo);
     }
 
-    public function testFromArrayRejectsMissingJsonRpcVersion(): void
+    public function testFromJsonPreservesResultJsonShape(): void
+    {
+        $message = RpcMessage::fromJson(
+            '{"jsonrpc":"2.0","id":"1","result":{"inputSchema":{"type":"object","properties":{},"required":[]}}}'
+        );
+
+        $result = $message->getResult();
+        $this->assertInstanceOf(stdClass::class, $result);
+        $this->assertInstanceOf(stdClass::class, $result->inputSchema);
+        $this->assertInstanceOf(stdClass::class, $result->inputSchema->properties);
+        $this->assertIsArray($result->inputSchema->required);
+    }
+
+    public function testFromJsonPreservesParamsJsonShape(): void
+    {
+        $message = RpcMessage::fromJson(
+            '{"jsonrpc":"2.0","method":"tools/call","id":"1","params":{"name":"test","arguments":{},"tags":[]}}'
+        );
+
+        $params = $message->getParams();
+        $this->assertInstanceOf(stdClass::class, $params);
+        $this->assertSame('test', $params->name);
+        $this->assertInstanceOf(stdClass::class, $params->arguments);
+        $this->assertIsArray($params->tags);
+    }
+
+    public function testFromJsonPreservesTopLevelParamsAndResultArrays(): void
+    {
+        $request = RpcMessage::fromJson(
+            '{"jsonrpc":"2.0","method":"notifications/progress","params":[]}'
+        );
+        $response = RpcMessage::fromJson(
+            '{"jsonrpc":"2.0","id":"1","result":[]}'
+        );
+
+        $this->assertSame([], $request->getParams());
+        $this->assertSame([], $response->getResult());
+    }
+
+    public function testFromJsonPreservesErrorJsonShape(): void
+    {
+        $message = RpcMessage::fromJson(
+            '{"jsonrpc":"2.0","id":"1","error":{"code":-32602,"message":"Invalid params","data":{"details":{},"items":[]}}}'
+        );
+
+        $this->assertTrue($message->isError());
+        $this->assertSame(-32602, $message->getErrorCode());
+        $this->assertSame('Invalid params', $message->getErrorMessage());
+
+        $error = $message->getError();
+        $this->assertInstanceOf(stdClass::class, $error);
+        $this->assertSame(-32602, $error->code);
+        $this->assertSame('Invalid params', $error->message);
+        $this->assertInstanceOf(stdClass::class, $error->data);
+        $this->assertInstanceOf(stdClass::class, $error->data->details);
+        $this->assertIsArray($error->data->items);
+    }
+
+    public function testFromJsonPreservesNumericObjectKeysAsObject(): void
+    {
+        $message = RpcMessage::fromJson(
+            '{"jsonrpc":"2.0","id":"1","result":{"map":{"0":"x"},"list":["x"]}}'
+        );
+
+        $result = $message->getResult();
+        $this->assertInstanceOf(stdClass::class, $result->map);
+        $this->assertSame(['0' => 'x'], get_object_vars($result->map));
+        $this->assertIsArray($result->list);
+
+        $roundTripped = json_decode($message->toJson(), false, 512, JSON_THROW_ON_ERROR);
+        $this->assertInstanceOf(stdClass::class, $roundTripped->result->map);
+        $this->assertIsArray($roundTripped->result->list);
+    }
+
+    public function testFromJsonPreservesNumericObjectKeysInParamsAndErrorData(): void
+    {
+        $request = RpcMessage::fromJson(
+            '{"jsonrpc":"2.0","method":"tools/call","id":"1","params":{"map":{"0":"x"},"list":["x"]}}'
+        );
+        $params = $request->getParams();
+
+        $this->assertInstanceOf(stdClass::class, $params->map);
+        $this->assertSame(['0' => 'x'], get_object_vars($params->map));
+        $this->assertIsArray($params->list);
+
+        $errorResponse = RpcMessage::fromJson(
+            '{"jsonrpc":"2.0","id":"1","error":{"code":-32602,"message":"Invalid params","data":{"map":{"0":"x"},"list":["x"]}}}'
+        );
+        $error = $errorResponse->getError();
+
+        $this->assertInstanceOf(stdClass::class, $error->data->map);
+        $this->assertSame(['0' => 'x'], get_object_vars($error->data->map));
+        $this->assertIsArray($error->data->list);
+    }
+
+    public function testToolsListInputSchemaRoundTripsWithEmptyPropertiesObject(): void
+    {
+        $json = '{"jsonrpc":"2.0","id":"1","result":{"tools":[{"name":"report","inputSchema":{"type":"object","properties":{"datapoints":{"type":"object","properties":{}}},"required":[]}}]}}';
+
+        $message = RpcMessage::fromJson($json);
+        $result = $message->getResult();
+
+        $this->assertInstanceOf(stdClass::class, $result->tools[0]->inputSchema->properties->datapoints->properties);
+
+        $encoded = $message->toJson();
+        $roundTripped = json_decode($encoded, false, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertInstanceOf(stdClass::class, $roundTripped->result->tools[0]->inputSchema->properties->datapoints->properties);
+        $this->assertSame([], $roundTripped->result->tools[0]->inputSchema->required);
+    }
+
+    public function testFromJsonRejectsNullMethod(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('method');
+
+        RpcMessage::fromJson('{"jsonrpc":"2.0","method":null,"id":"1"}');
+    }
+
+    public function testFromJsonRejectsScalarParams(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('params');
+
+        RpcMessage::fromJson('{"jsonrpc":"2.0","method":"tools/list","id":"1","params":"bad"}');
+    }
+
+    public function testFromJsonRejectsResponseWithResultAndError(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('response');
+
+        RpcMessage::fromJson('{"jsonrpc":"2.0","id":"1","result":{},"error":{"code":-32603,"message":"bad"}}');
+    }
+
+    public function testFromJsonRejectsSuccessResponseWithoutId(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('response');
+
+        RpcMessage::fromJson('{"jsonrpc":"2.0","result":{}}');
+    }
+
+    public function testFromJsonRejectsInvalidErrorShape(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('error');
+
+        RpcMessage::fromJson('{"jsonrpc":"2.0","id":"1","error":null}');
+    }
+
+    public function testFromJsonRejectsInvalidIdShape(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('id');
+
+        RpcMessage::fromJson('{"jsonrpc":"2.0","method":"tools/list","id":{}}');
+    }
+
+    public function testFromDecodedJsonRejectsMissingJsonRpcVersion(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('JSON-RPC version');
 
-        RpcMessage::fromArray([]);
+        RpcMessage::fromDecodedJson(new stdClass());
     }
 
-    public function testFromArrayRejectsWrongJsonRpcVersion(): void
+    public function testFromDecodedJsonRejectsWrongJsonRpcVersion(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('JSON-RPC version');
 
-        RpcMessage::fromArray([
-            'jsonrpc' => '1.0',
-            'id' => 1,
-            'result' => null,
-        ]);
+        RpcMessage::fromDecodedJson($this->decodeObject('{"jsonrpc":"1.0","id":1,"result":null}'));
     }
 
-    public function testFromArrayParsesNotificationMessage(): void
+    public function testFromDecodedJsonParsesNotificationMessage(): void
     {
-        $message = RpcMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'method' => 'notifications/initialized',
-            'params' => ['status' => 'ready'],
-        ]);
+        $message = RpcMessage::fromDecodedJson(
+            $this->decodeObject('{"jsonrpc":"2.0","method":"notifications/initialized","params":{"status":"ready"}}')
+        );
 
         $this->assertTrue($message->isNotification());
         $this->assertSame('notifications/initialized', $message->getMethod());
         $this->assertNull($message->getId());
-        $this->assertSame(['status' => 'ready'], $message->getParams());
+        $this->assertInstanceOf(stdClass::class, $message->getParams());
+        $this->assertSame('ready', $message->getParams()->status);
     }
 
-    public function testFromArrayParsesResponseMessage(): void
+    public function testFromDecodedJsonParsesResponseMessage(): void
     {
-        $message = RpcMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 2,
-            'result' => ['x' => 1],
-        ]);
+        $message = RpcMessage::fromDecodedJson(
+            $this->decodeObject('{"jsonrpc":"2.0","id":2,"result":{"x":1}}')
+        );
 
         $this->assertTrue($message->isResponse());
         $this->assertSame(2, $message->getId());
-        $this->assertSame(['x' => 1], $message->getResult());
+        $this->assertInstanceOf(stdClass::class, $message->getResult());
+        $this->assertSame(1, $message->getResult()->x);
     }
 
-    public function testFromArrayParsesErrorMessage(): void
+    public function testFromDecodedJsonParsesErrorMessage(): void
     {
-        $message = RpcMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 3,
-            'error' => [
-                'code' => -32600,
-                'message' => 'Invalid Request',
-            ],
-        ]);
+        $message = RpcMessage::fromDecodedJson(
+            $this->decodeObject('{"jsonrpc":"2.0","id":3,"error":{"code":-32600,"message":"Invalid Request"}}')
+        );
 
         $this->assertTrue($message->isError());
         $this->assertSame(3, $message->getId());
         $this->assertSame(-32600, $message->getErrorCode());
         $this->assertSame('Invalid Request', $message->getErrorMessage());
+    }
+
+    private function decodeObject(string $json): stdClass
+    {
+        $decoded = json_decode($json, false, 512, JSON_THROW_ON_ERROR);
+        $this->assertInstanceOf(stdClass::class, $decoded);
+
+        return $decoded;
     }
 }


### PR DESCRIPTION
## Summary
- Decode inbound MCP JSON-RPC messages as object trees so JSON object/array shape survives parsing, access, and re-encoding.
- Preserve shapes through `RpcMessage::fromJson()`, `McpChannel` processing, accessors, and `toArray()`.
- Remove lossy associative-array fallback parsing and tighten JSON-RPC envelope and batch validation.
- Keep outbound MCP object fields such as empty params, arguments, and capabilities encoded as `{}` where the protocol expects objects.

## Reason
MCP schemas distinguish JSON objects/maps from arrays. Associative-array decoding collapses those shapes in PHP, so `{}`, `[]`, and numeric-key objects like `{"0":"x"}` can become indistinguishable or be re-encoded incorrectly. That is especially risky for MCP schemas such as `inputSchema.properties`, where empty objects and arrays have different meanings.

## Behavior change
This is BC-breaking for MCP payload accessors:
- Inbound `{}` is exposed as `stdClass`.
- Inbound `[]` remains a PHP array.
- Inbound `{"0":"x"}` remains a `stdClass`, not an array.
- `getParams()`, `getResult()`, `getError()`, and `toArray()` expose preserved decoded JSON shapes for inbound messages.

## Validation
- `make test-all`
- `make phpstan`

## Important
This PR must be released only with the next major version after merge, because it changes public MCP accessor return shapes.